### PR TITLE
Add initial Index template, view, and add layout template

### DIFF
--- a/catalog/static/css/styles.css
+++ b/catalog/static/css/styles.css
@@ -1,0 +1,5 @@
+.sidebar-nav {
+  margin-top: 20px;
+  padding: 0;
+  list-style: none;
+}

--- a/catalog/templates/catalog/index.html
+++ b/catalog/templates/catalog/index.html
@@ -1,0 +1,22 @@
+{%extends "catalog/layout.html"%}
+
+{%block title%}
+Home - Local Library
+{%endblock%}
+
+{%block content%}
+<h1>Local Library Home</h1>
+<p>
+  Welcome to LocalLibrary, a website developed by <em>Mozilla Developer Network</em>!
+</p>
+<h2>Dynamic Content</h2>
+<p>The library has the following record counts:</p>
+<ul>
+  <li>📕 <strong>Books:</strong> {{num_books}}</li>
+  <li>📔 <strong>Copies:</strong> {{num_instances}}</li>
+  <li>📚 <strong>Copies available:</strong> {{num_instances_available}}</li>
+  <li>✍️ <strong>Authors:</strong> {{num_authors}}</li>
+  <li>⭐ <strong>Genres:</strong> {{num_genres}}</li>
+</ul>
+<p>Also, there are <strong>{{the_books}}</strong> books with the word "The" on their title. 😮</p>
+{%endblock%}

--- a/catalog/templates/catalog/layout.html
+++ b/catalog/templates/catalog/layout.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>
+    {%block title%}
+    Local Library
+    {%endblock%}
+  </title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  {%load static%}
+  <link rel="stylesheet" href="{%static 'css/styles.css'%}">
+</head>
+
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-2">
+        {%block sidebar%}
+        <ul class="sidebar-nav">
+          <li><a href="{%url 'catalog:index'%}">Home</a></li>
+          <li><a href="">All books</a></li>
+          <li><a href="">All authors</a></li>
+        </ul>
+        {%endblock%}
+      </div>
+      <div class="col-sm-10">
+        {%block content%}
+        {%endblock%}
+      </div>
+    </div>
+  </div>
+
+</body>
+
+</html>

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -2,6 +2,5 @@ from django.urls import path
 
 from . import views
 
-urlpatterns = [
-  
-]
+app_name = "catalog"
+urlpatterns = [path("", views.index, name="index")]

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -1,3 +1,27 @@
 from django.shortcuts import render
 
-# Create your views here.
+from .models import Book, Author, BookInstance, Genre
+
+
+def index(request):
+    """View function for home page of site."""
+
+    num_books = Book.objects.all().count()
+    num_instances = BookInstance.objects.all().count()
+    num_instances_available = BookInstance.objects.filter(status__exact="a").count()
+    num_authors = (
+        Author.objects.count()
+    )  # The 'all()' is implied by default, so I could be left off.
+    num_genres = Genre.objects.count()
+    the_books = Book.objects.filter(title__icontains="the").count()
+
+    context = {
+        "num_books": num_books,
+        "num_instances": num_instances,
+        "num_instances_available": num_instances_available,
+        "num_authors": num_authors,
+        "num_genres": num_genres,
+        "the_books": the_books,
+    }
+
+    return render(request, "catalog/index.html", context=context)


### PR DESCRIPTION
For the Index page the additions were:
* Template, on `index.html`
* View, which now fetches some information from the database and server it on the context object.
* URL configuration, pointing to the correct page.

For the Layout the additions were:
* Reference to the `static/` directory to serve static content.
* Add a block for the page title with a default value.
* Add a block for the sidebar, with default content being a list of links to the home page, authors and books page.
* Add a block for the page content, empty by default.