### PR TITLE
Add RenewBookForm on forms.py and class views for Create, Update Books and Authors

### DIFF
--- a/catalog/forms.py
+++ b/catalog/forms.py
@@ -1,0 +1,22 @@
+import datetime
+
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+
+class RenewBookForm(forms.Form):
+    renewal_date = forms.DateField(
+        help_text="Enter a date between now and 4 weeks (the default is 3)."
+    )
+
+    def clean_renewal_date(self):
+        data = self.cleaned_data["renewal_date"]
+
+        if data < datetime.date.today():
+            raise ValidationError(_("Invalid date - renewal in past"))
+
+        if data > datetime.date.today() + datetime.timedelta(weeks=4):
+            raise ValidationError(_("Invalid date - renewal more than 4 weeks ahead"))
+
+        return data

--- a/catalog/templates/catalog/all_borrowed.html
+++ b/catalog/templates/catalog/all_borrowed.html
@@ -11,14 +11,18 @@
       <th>Title</th>
       <th>Borrower</th>
       <th>Due Date</th>
+      <th>Renew</th>
     </tr>
   </thead>
   <tbody>
     {%for inst in bookinstance_list %}
     <tr>
       <td>{{inst.book.title}}</td>
-      <td>{{inst.borrower.get_username}}</td>
+      <td><a href="{% url 'catalog:book-detail' inst.book.pk %}">{{ inst.book.title }}</a></td>
       <td class="{% if inst.is_overdue %}text-danger{% endif %}">{{inst.due_back}}</td>
+      {% if perms.catalog.can_mark_returned %}
+      <td><a href="{% url 'catalog:renew-book-librarian' inst.id%}">Renew</a></td>
+      {%endif%}
     </tr>
     {%endfor%}
   </tbody>

--- a/catalog/templates/catalog/author_confirm_delete.html
+++ b/catalog/templates/catalog/author_confirm_delete.html
@@ -1,0 +1,24 @@
+{% extends "catalog/layout.html"%}
+
+{% block content %}
+<h1>Delete Author: {{author}}</h1>
+
+{%if author.book_set.all%}
+<p>You can't delete this author until all their books have been deleted:</p>
+<ul>
+    {% for book in author.book_set.all %}
+    <li>
+        <a href="{% url 'catalog:book-detail' book.pk %}">{{book}}</a>
+        ({{book.bookinstance_set.all.count}})
+    </li>
+    {%endfor%}
+</ul>
+{% else %}
+<p>Are you sure you want to delete the author?</p>
+
+<form action="" method="POST">
+    {% csrf_token %}
+    <input type="submit" action="" value="Yes, delete.">
+</form>
+{%endif%}
+{% endblock %}

--- a/catalog/templates/catalog/author_detail.html
+++ b/catalog/templates/catalog/author_detail.html
@@ -1,5 +1,21 @@
 {%extends "catalog/layout.html"%}
 
+{%block sidebar%}
+{{block.super}}
+
+{% if perms.catalog.change_author or perms.catalog.delete_author %}
+<hr>
+<ul class="sidebar-nav">
+  {% if perms.catalog.change_author %}
+  <li><a href="{%url 'catalog:author-update' author.id %}">Update author</a></li>
+  {%endif%}
+  {% if not author.book_set.all and perms.catalog.delete_author %}
+  <li><a href="{%url 'catalog:author-delete' author.id%}">Delete author</a></li>
+  {%endif%}
+</ul>
+{%endif%}
+{%endblock%}
+
 {%block content%}
 <h1>{{author.first_name}} {{author.last_name}}</h1>
 <p>Born in: <em>{{author.date_of_birth}}</em></p>

--- a/catalog/templates/catalog/author_form.html
+++ b/catalog/templates/catalog/author_form.html
@@ -1,0 +1,11 @@
+{% extends "catalog/layout.html" %}
+
+{%block content%}
+<form action="" method="post">
+    {% csrf_token %}
+    <table>
+        {{form.as_table}}
+    </table>
+    <input type="submit" value="Submit">
+</form>
+{%endblock%}

--- a/catalog/templates/catalog/book_detail.html
+++ b/catalog/templates/catalog/book_detail.html
@@ -1,5 +1,18 @@
 {%extends "catalog/layout.html"%}
 
+{%block sidebar%}
+
+{{block.super}}
+
+{%if perms.catalog.change_book %}
+<hr>
+<ul class="sidebar-nav">
+  <li><a href="{%url 'catalog:book-update' book.id%}">Update book</a></li>
+</ul>
+{%endif%}
+
+{%endblock%}
+
 {%block content%}
 <h1>Title: {{book.title}}</h1>
 

--- a/catalog/templates/catalog/book_form.html
+++ b/catalog/templates/catalog/book_form.html
@@ -1,0 +1,15 @@
+{% extends "catalog/layout.html" %}
+
+{% block content %}
+<h1>Create a book</h1>
+
+<form action="" method="post">
+    {% csrf_token %}
+
+    <table>
+        {{form.as_table}}
+    </table>
+
+    <input type="submit" value="Create">
+</form>
+{% endblock %}

--- a/catalog/templates/catalog/book_renew_librarian.html
+++ b/catalog/templates/catalog/book_renew_librarian.html
@@ -1,0 +1,17 @@
+{%extends "catalog/layout.html"%}
+
+{%block content%}
+<h1>Renew: {{book_instance.book.title}}</h1>
+<p>Borrower: {{book_instance.borrower}}</p>
+<p {% if book_instance.is_overdue %} class="text-danger" {%endif%}>
+    Due date: {{book_instance.due_back}}
+</p>
+
+<form action="" method="post">
+    {% csrf_token %}
+    <table>
+        {{form.as_table}}
+    </table>
+    <input type="submit" value="Submit">
+</form>
+{%endblock%}

--- a/catalog/templates/catalog/layout.html
+++ b/catalog/templates/catalog/layout.html
@@ -25,6 +25,7 @@
           <li><a href="{%url 'catalog:books'%}">All books</a></li>
           <li><a href="{%url 'catalog:authors'%}">All authors</a></li>
           {% if user.is_authenticated %}
+          <hr>
           <li>User: {{user.get_username}}</li>
           <li><a href="{% url 'catalog:my-borrowed' %}">My Borrowed</a></li>
           <li>
@@ -33,9 +34,13 @@
               <button type="submit" class="btn btn-link">Logout</button>
             </form>
           </li>
-          {% if perms.catalog.can_mark_returned %}
+          {% if user.is_staff %}
+          <hr>
           <li>Staff</li>
           <li><a href="{%url 'catalog:all-borrowed'%}">All borrowed</a></li>
+          {% if perms.catalog.add_author %}
+          <li><a href="{%url 'catalog:author-create'%}">Create author</a></li>
+          {% endif %}
           {%endif%}
           {% else %}
           <li><a href="{% url 'login'%}?next={{request.path}}">Login</a></li>

--- a/catalog/templates/catalog/layout.html
+++ b/catalog/templates/catalog/layout.html
@@ -41,6 +41,9 @@
           {% if perms.catalog.add_author %}
           <li><a href="{%url 'catalog:author-create'%}">Create author</a></li>
           {% endif %}
+          {% if perms.catalog.add_book %}
+          <li><a href="{%url 'catalog:book-create'%}">Create book</a></li>
+          {% endif %}
           {%endif%}
           {% else %}
           <li><a href="{% url 'login'%}?next={{request.path}}">Login</a></li>

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -17,4 +17,6 @@ urlpatterns = [
     path("author/create/", views.AuthorCreate.as_view(), name="author-create"),
     path("author/<int:pk>/update/", views.AuthorUpdate.as_view(), name="author-update"),
     path("author/<int:pk>/delete/", views.AuthorDelete.as_view(), name="author-delete"),
+    path("book/create/", views.BookCreate.as_view(), name="book-create"),
+    path("book/<int:pk>/update/", views.BookUpdate.as_view(), name="book-update"),
 ]

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -14,4 +14,7 @@ urlpatterns = [
     path(
         "book/<uuid:pk>/renew/", views.renew_book_librarian, name="renew-book-librarian"
     ),
+    path("author/create/", views.AuthorCreate.as_view(), name="author-create"),
+    path("author/<int:pk>/update/", views.AuthorUpdate.as_view(), name="author-update"),
+    path("author/<int:pk>/delete/", views.AuthorDelete.as_view(), name="author-delete"),
 ]

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -11,4 +11,7 @@ urlpatterns = [
     path("authors/<int:pk>", views.AuthorDetailView.as_view(), name="author-detail"),
     path("mybooks/", views.LoanedBooksByUserListView.as_view(), name="my-borrowed"),
     path("allborrowed", views.AllBorrowed.as_view(), name="all-borrowed"),
+    path(
+        "book/<uuid:pk>/renew/", views.renew_book_librarian, name="renew-book-librarian"
+    ),
 ]

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -4,8 +4,9 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.views import generic
+from django.views.generic.edit import CreateView, UpdateView, DeleteView
 
 from .models import Book, Author, BookInstance, Genre
 from .forms import RenewBookForm
@@ -108,3 +109,32 @@ def renew_book_librarian(request, pk):
 
     context = {"form": form, "book_instance": book_instance}
     return render(request, "catalog/book_renew_librarian.html", context)
+
+
+class AuthorCreate(PermissionRequiredMixin, CreateView):
+    model = Author
+    fields = ["first_name", "last_name", "date_of_birth", "date_of_death"]
+    # initial = {"date_of_death": "11/11/2023"}
+    permission_required = "catalog.add_author"
+
+
+class AuthorUpdate(PermissionRequiredMixin, UpdateView):
+    model = Author
+    #! NOT RECOMMEND, COULD RESULT IN UNINTENDED FIELDS BEING SHOW
+    fields = "__all__"
+    permission_required = "catalog.change_author"
+
+
+class AuthorDelete(PermissionRequiredMixin, DeleteView):
+    model = Author
+    success_url = reverse_lazy("catalog:authors")
+    permission_required = "catalog.delete_author"
+
+    def form_valid(self, form):
+        try:
+            self.object.delete()
+            return HttpResponseRedirect(self.success_url)
+        except Exception as e:
+            return HttpResponseRedirect(
+                reverse("author-delete", kwargs={"pk": self.object.pk})
+            )

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -1,8 +1,14 @@
+import datetime
+
+from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.views import generic
 
 from .models import Book, Author, BookInstance, Genre
+from .forms import RenewBookForm
 
 
 def index(request):
@@ -78,3 +84,27 @@ class AllBorrowed(PermissionRequiredMixin, generic.ListView):
         return BookInstance.objects.filter(
             borrower__isnull=False, status__exact="o"
         ).order_by("due_back")
+
+
+@login_required
+@permission_required("catalog.can_mark_returned", raise_exception=True)
+def renew_book_librarian(request, pk):
+    """On a GET call will render the Renew Form, and on a POST will process it's data."""
+
+    book_instance = get_object_or_404(BookInstance, pk=pk)
+
+    if request.method == "POST":
+        form = RenewBookForm(request.POST)
+
+        if form.is_valid():
+            book_instance.due_back = form.cleaned_data["renewal_date"]
+            book_instance.save()
+
+            return HttpResponseRedirect(reverse("all-borrowed"))
+
+    else:
+        proposed_renewal_date = datetime.date.today() + datetime.timedelta(weeks=3)
+        form = RenewBookForm(initial={"renewal_date": proposed_renewal_date})
+
+    context = {"form": form, "book_instance": book_instance}
+    return render(request, "catalog/book_renew_librarian.html", context)

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -138,3 +138,15 @@ class AuthorDelete(PermissionRequiredMixin, DeleteView):
             return HttpResponseRedirect(
                 reverse("author-delete", kwargs={"pk": self.object.pk})
             )
+
+
+class BookCreate(PermissionRequiredMixin, CreateView):
+    model = Book
+    permission_required = "catalog.add_book"
+    fields = ["title", "summary", "author", "isbn", "genre", "language"]
+
+
+class BookUpdate(PermissionRequiredMixin, UpdateView):
+    model = Book
+    permission_required = "catalog.change_book"
+    fields = ["title", "summary", "author", "isbn", "genre", "language"]


### PR DESCRIPTION
Add the separate form `RenewBookForm` on `forms.py` file that allows Librarians group members to renew a book. A new view was also added to store this form.

Using the standard generic classes provided by Django a Create view, Update view and Delete view for Authors and as a side task the Create view and Update view were added. Access to these new views is also exclusive to Librarians. These last implementations required new permissions, which were added on the admin console.